### PR TITLE
fix: fix mismatched argument name for kernelConfig

### DIFF
--- a/pipeline/default.nix
+++ b/pipeline/default.nix
@@ -36,7 +36,7 @@ let
       src = patchedKernelSrc;
       defconfigs = kernelDefconfigs;
       makeFlags = kernelMakeFlags;
-      extraKernelConfigs = kernelConfig;
+      additionalKernelConfig = kernelConfig;
     };
 
     kernelBuildGcc = callPackage ./build-kernel-gcc.nix {
@@ -44,7 +44,7 @@ let
       src = patchedKernelSrc;
       defconfigs = kernelDefconfigs;
       makeFlags = kernelMakeFlags;
-      extraKernelConfigs = kernelConfig;
+      additionalKernelConfig = kernelConfig;
     };
 
     kernelBuild = if clangVersion == null then kernelBuildGcc else kernelBuildClang;


### PR DESCRIPTION
https://github.com/xddxdd/nix-kernelsu-builder/blob/98de8a810741333ca9a9882168641583b11730e4/pipeline/default.nix#L39 using `extraKernelConfigs` while https://github.com/xddxdd/nix-kernelsu-builder/blob/98de8a810741333ca9a9882168641583b11730e4/pipeline/build-kernel-clang.nix#L32 receive `additionalKernelConfig`