### PR TITLE
general: add baseband-guard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Each kernel definition takes these arguments:
 - `susfs.kernelPatch`: Path to SusFS's kernel patch. If set, will override the patch used. Useful for overriding patch to adapt to different kernel versions. If set to null, will disable patching kernel.
 - `susfs.kernelsuPatch`: Path to SusFS's KernelSU patch. If set, will override the patch used. Used for overriding patch to adapt to different KernelSU versions. If set to null, will disable patching KernelSU.
 
+- `bbg.enable`: Whether to enable [Baseband-guard] integration.
+- `bbg.src`: Source of BBG. Note that for modern kernels (e.g., GKI), you must explicitly append baseband_guard to `CONFIG_LSM` in `kernelConfig`.
+
 - `kernelConfig`: Additional kernel config to be applied during build.
 - `kernelDefconfigs`: List of kernel config files applied during build.
   - Older kernels usually have a single `_defconfig` file. Newer devices may have several.

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -41,6 +41,27 @@
         },
         "version": "6f88dff82b786e879b255a8e1523547c4f62d031"
     },
+    "baseband-guard": {
+        "cargoLock": null,
+        "date": "2026-01-01",
+        "extract": null,
+        "name": "baseband-guard",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "vc-teahouse",
+            "repo": "Baseband-guard",
+            "rev": "2f60136960effdf82cf71640ba019999fa14e655",
+            "sha256": "sha256-2hWoYghRcaJFbfYTWas09XcIQVYtklrRgpq6Yd9CB8U=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "2f60136960effdf82cf71640ba019999fa14e655"
+    },
     "gcc-aarch64-linux-android": {
         "cargoLock": null,
         "date": "2020-02-22",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -30,6 +30,18 @@
     };
     date = "2025-05-18";
   };
+  baseband-guard = {
+    pname = "baseband-guard";
+    version = "2f60136960effdf82cf71640ba019999fa14e655";
+    src = fetchFromGitHub {
+      owner = "vc-teahouse";
+      repo = "Baseband-guard";
+      rev = "2f60136960effdf82cf71640ba019999fa14e655";
+      fetchSubmodules = false;
+      sha256 = "sha256-2hWoYghRcaJFbfYTWas09XcIQVYtklrRgpq6Yd9CB8U=";
+    };
+    date = "2026-01-01";
+  };
   gcc-aarch64-linux-android = {
     pname = "gcc-aarch64-linux-android";
     version = "5797d7f622321e734558bd3372a9ab5ad6e6a48e";

--- a/flake-modules/default.nix
+++ b/flake-modules/default.nix
@@ -94,7 +94,18 @@
                 default = "${config.susfs.src}/kernel_patches/KernelSU/10_enable_susfs_for_ksu.patch";
               };
             };
-
+            bbg = {
+              enable = lib.mkOption {
+                type = lib.types.bool;
+                description = "Whether to enable baseband-guard";
+                default = false;
+              };
+              src = lib.mkOption {
+                type = lib.types.nullOr lib.types.package;
+                description = "Source of bbg.";
+                default = sources.baseband-guard.src;
+              };
+            };
             kernelConfig = lib.mkOption {
               type = lib.types.lines;
               description = "Additional kernel config to be applied during build";

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -1,102 +1,106 @@
 [anykernel-kernelsu]
-src.git = "https://github.com/Kernel-SU/AnyKernel3.git"
 fetch.github = "Kernel-SU/AnyKernel3"
+src.git = "https://github.com/Kernel-SU/AnyKernel3.git"
 
 [anykernel-osm0sis]
-src.git = "https://github.com/osm0sis/AnyKernel3.git"
 fetch.github = "osm0sis/AnyKernel3"
+src.git = "https://github.com/osm0sis/AnyKernel3.git"
+
+[baseband-guard]
+fetch.github = "vc-teahouse/Baseband-guard"
+src.git = "https://github.com/vc-teahouse/Baseband-guard.git"
 
 [gcc-aarch64-linux-android]
-src.git = "https://github.com/kindle4jerry/aarch64-linux-android-4.9-bakup.git"
 fetch.github = "kindle4jerry/aarch64-linux-android-4.9-bakup"
+src.git = "https://github.com/kindle4jerry/aarch64-linux-android-4.9-bakup.git"
 
 [gcc-arm-linux-androideabi]
-src.git = "https://github.com/KudProject/arm-linux-androideabi-4.9.git"
 fetch.github = "KudProject/arm-linux-androideabi-4.9"
+src.git = "https://github.com/KudProject/arm-linux-androideabi-4.9.git"
+
+[kernelsu-next]
+fetch.git = "https://github.com/rifsxd/KernelSU-Next.git"
+src.github = "rifsxd/KernelSU-Next"
+
+[kernelsu-next-revision-code]
+fetch.url = "https://example.com"
+src.webpage = "https://api.github.com/repos/rifsxd/KernelSU-Next/releases?per_page=1"
+src.regex = "download\\/v[0-9\\._]+\\/KernelSU[^\"]*_([0-9]+)-release\\.apk"
 
 [kernelsu-stable]
+fetch.git = "https://github.com/tiann/KernelSU.git"
 # src.github = "tiann/KernelSU"
 src.manual = "v0.9.5"
-fetch.git = "https://github.com/tiann/KernelSU.git"
 
 [kernelsu-stable-revision-code]
+fetch.url = "https://example.com"
 # src.webpage = "https://api.github.com/repos/tiann/KernelSU/releases?per_page=1"
 # src.regex = "download\\/v[0-9\\._]+\\/KernelSU[^\"]*_([0-9]+)-release\\.apk"
 src.manual = "11872"
-fetch.url = "https://example.com"
-
-[kernelsu-next]
-src.github = "rifsxd/KernelSU-Next"
-fetch.git = "https://github.com/rifsxd/KernelSU-Next.git"
-
-[kernelsu-next-revision-code]
-src.webpage = "https://api.github.com/repos/rifsxd/KernelSU-Next/releases?per_page=1"
-src.regex = "download\\/v[0-9\\._]+\\/KernelSU[^\"]*_([0-9]+)-release\\.apk"
-fetch.url = "https://example.com"
 
 [linux-amazon-karnak]
+fetch.github = "mt8163/android_kernel_amazon_karnak_4.9"
 src.git = "https://github.com/mt8163/android_kernel_amazon_karnak_4.9.git"
 src.branch = "lineage-20.0"
-fetch.github = "mt8163/android_kernel_amazon_karnak_4.9"
 
 [linux-moto-rtwo-lineageos-21]
+fetch.github = "LineageOS/android_kernel_motorola_sm8550"
 src.git = "https://github.com/LineageOS/android_kernel_motorola_sm8550.git"
 src.branch = "lineage-21"
-fetch.github = "LineageOS/android_kernel_motorola_sm8550"
 
 [linux-moto-rtwo-lineageos-22_1]
+fetch.github = "LineageOS/android_kernel_motorola_sm8550"
 src.git = "https://github.com/LineageOS/android_kernel_motorola_sm8550.git"
 src.branch = "lineage-22.1"
-fetch.github = "LineageOS/android_kernel_motorola_sm8550"
-
-[linux-oneplus-8t-blu-spark]
-src.git = "https://github.com/engstk/op8.git"
-src.branch = "blu_spark-14-custom"
-fetch.github = "engstk/op8"
 
 [linux-oneplus-13]
+fetch.github = "OnePlusOSS/android_kernel_common_oneplus_sm8750"
 src.git = "https://github.com/OnePlusOSS/android_kernel_common_oneplus_sm8750.git"
 src.branch = "oneplus/sm8750_v_15.0.0_oneplus_13"
-fetch.github = "OnePlusOSS/android_kernel_common_oneplus_sm8750"
+
+[linux-oneplus-8t-blu-spark]
+fetch.github = "engstk/op8"
+src.git = "https://github.com/engstk/op8.git"
+src.branch = "blu_spark-14-custom"
 
 [oneplus-13-sched-ext]
-src.git = "https://github.com/HanKuCha/sched_ext.git"
 fetch.github = "HanKuCha/sched_ext"
+src.git = "https://github.com/HanKuCha/sched_ext.git"
 
 [sukisu]
+fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 src.git = "https://github.com/SukiSU-Ultra/SukiSU-Ultra.git"
 src.branch = "main"
-fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 
 [sukisu-nongki]
+fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 src.git = "https://github.com/SukiSU-Ultra/SukiSU-Ultra.git"
 src.branch = "nongki"
-fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 
 [sukisu-patch]
-src.git = "https://github.com/SukiSU-Ultra/SukiSU_patch.git"
 fetch.github = "SukiSU-Ultra/SukiSU_patch"
+src.git = "https://github.com/SukiSU-Ultra/SukiSU_patch.git"
 
 [sukisu-revision-code]
+fetch.url = "https://example.com"
 src.webpage = "https://api.github.com/repos/SukiSU-Ultra/SukiSU-Ultra/releases?per_page=1"
 src.regex = "download\\/v[0-9\\._]+\\/SukiSU[^\"]*_([0-9]+)-release\\.apk"
-fetch.url = "https://example.com"
 
 [sukisu-susfs]
+fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 src.git = "https://github.com/SukiSU-Ultra/SukiSU-Ultra.git"
 src.branch = "susfs-main"
-fetch.github = "SukiSU-Ultra/SukiSU-Ultra"
 
 [susfs-android13-5_15]
+fetch.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 src.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 src.branch = "gki-android13-5.15"
-fetch.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 
 [susfs-android15-6_6]
+fetch.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 src.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 src.branch = "gki-android15-6.6"
-fetch.git = "https://gitlab.com/simonpunk/susfs4ksu.git"
 
 [wildplus-kernel-patches]
-src.git = "https://github.com/WildPlusKernel/kernel_patches.git"
 fetch.github = "WildPlusKernel/kernel_patches"
+src.git = "https://github.com/WildPlusKernel/kernel_patches.git"

--- a/pipeline/build-kernel-clang.nix
+++ b/pipeline/build-kernel-clang.nix
@@ -28,6 +28,7 @@
   defconfigs,
   kernelSU,
   susfs,
+  bbg,
   makeFlags,
   additionalKernelConfig ? "",
   ...
@@ -53,6 +54,7 @@ let
       additionalKernelConfig
       kernelSU
       susfs
+      bbg
       finalMakeFlags
       ;
   };

--- a/pipeline/build-kernel-gcc.nix
+++ b/pipeline/build-kernel-gcc.nix
@@ -28,6 +28,7 @@
   defconfigs,
   kernelSU,
   susfs,
+  bbg,
   makeFlags,
   additionalKernelConfig ? "",
   ...
@@ -41,7 +42,8 @@ let
     "CROSS_COMPILE=aarch64-linux-android-"
     "CROSS_COMPILE_ARM32=arm-linux-androideabi-"
     "O=$out"
-  ] ++ makeFlags;
+  ]
+  ++ makeFlags;
 
   defconfig = lib.last defconfigs;
   kernelConfigCmd = pkgs.callPackage ./kernel-config-cmd.nix {
@@ -52,6 +54,7 @@ let
       additionalKernelConfig
       kernelSU
       susfs
+      bbg
       finalMakeFlags
       ;
   };

--- a/pipeline/default.nix
+++ b/pipeline/default.nix
@@ -17,6 +17,7 @@
   kernelSrc,
   oemBootImg,
   susfs,
+  bbg,
   prePatch,
   postPatch,
 }:
@@ -26,6 +27,7 @@ let
       inherit
         kernelSU
         susfs
+        bbg
         prePatch
         postPatch
         ;
@@ -39,6 +41,7 @@ let
         clangVersion
         kernelSU
         susfs
+        bbg
         ;
       src = patchedKernelSrc;
       defconfigs = kernelDefconfigs;
@@ -47,7 +50,12 @@ let
     };
 
     kernelBuildGcc = callPackage ./build-kernel-gcc.nix {
-      inherit arch kernelSU susfs;
+      inherit
+        arch
+        kernelSU
+        susfs
+        bbg
+        ;
       src = patchedKernelSrc;
       defconfigs = kernelDefconfigs;
       makeFlags = kernelMakeFlags;

--- a/pipeline/kernel-config-cmd.nix
+++ b/pipeline/kernel-config-cmd.nix
@@ -7,6 +7,7 @@
   additionalKernelConfig,
   kernelSU,
   susfs,
+  bbg,
   finalMakeFlags,
 }:
 ''
@@ -40,6 +41,9 @@
   CONFIG_KSU_SUSFS_SUS_SU=y
   CONFIG_TMPFS_XATTR=y
   CONFIG_TMPFS_POSIX_ACL=y
+'')
++ (lib.optionalString bbg.enable ''
+  CONFIG_BBG=y
 '')
 + ''
   ${additionalKernelConfig}

--- a/pipeline/patch-kernel-src.nix
+++ b/pipeline/patch-kernel-src.nix
@@ -10,6 +10,7 @@
   patches,
   kernelSU,
   susfs,
+  bbg,
   prePatch,
   postPatch,
   ...
@@ -31,49 +32,78 @@ stdenv.mkDerivation {
   ];
 
   inherit prePatch;
-  postPatch =
-    ''
-      export HOME=$(pwd)
-    ''
-    + (lib.optionalString kernelSU.enable ''
-      cp -r ${kernelSU.src} ${kernelSU.subdirectory}
-      chmod -R +w ${kernelSU.subdirectory}
-    '')
-    + (lib.optionalString susfs.enable ''
-      cp -r ${susfs.src}/kernel_patches/fs/* fs/
-      cp -r ${susfs.src}/kernel_patches/include/linux/* include/linux/
-      chmod -R +w fs include/linux
-    '')
-    + (lib.optionalString (susfs.enable && susfs.kernelPatch != null) ''
-      echo "applying patch ${susfs.kernelPatch}"
-      patch -p1 < ${susfs.kernelPatch}
-    '')
-    + (lib.optionalString (susfs.enable && susfs.kernelsuPatch != null) ''
-      pushd ${kernelSU.subdirectory}
-      echo "applying patch ${susfs.kernelsuPatch}"
-      patch -p1 < ${susfs.kernelsuPatch}
-      popd
-    '')
-    + ''
-      patchShebangs .
+  postPatch = ''
+    export HOME=$(pwd)
+  ''
+  + (lib.optionalString kernelSU.enable ''
+    cp -r ${kernelSU.src} ${kernelSU.subdirectory}
+    chmod -R +w ${kernelSU.subdirectory}
+  '')
+  + (lib.optionalString susfs.enable ''
+    cp -r ${susfs.src}/kernel_patches/fs/* fs/
+    cp -r ${susfs.src}/kernel_patches/include/linux/* include/linux/
+    chmod -R +w fs include/linux
+  '')
+  + (lib.optionalString (susfs.enable && susfs.kernelPatch != null) ''
+    echo "applying patch ${susfs.kernelPatch}"
+    patch -p1 < ${susfs.kernelPatch}
+  '')
+  + (lib.optionalString (susfs.enable && susfs.kernelsuPatch != null) ''
+    pushd ${kernelSU.subdirectory}
+    echo "applying patch ${susfs.kernelsuPatch}"
+    patch -p1 < ${susfs.kernelsuPatch}
+    popd
+  '')
+  # BBG integration NOTE:
+  # For GKI/modern kernels, simply enabling CONFIG_BBG=y is NOT sufficient.
+  # The Baseband-guard Makefile enforces a check to ensure "baseband_guard" is
+  # explicitly present in the CONFIG_LSM list. If it is missing, the build
+  # will fail with a "Please follow Baseband-guard's README" error.
+  # You MUST manually append ",baseband_guard" to the CONFIG_LSM string in
+  # your kernelConfig (e.g., CONFIG_LSM="...,bpf,baseband_guard").
+  + (lib.optionalString bbg.enable ''
+    echo "Integrating Baseband-guard..."
+    mkdir -p security/baseband-guard
+    cp -r ${bbg.src}/* security/baseband-guard/
+    chmod -R +w security/baseband-guard
 
-      # These files may break Wi-Fi
-      # https://gitlab.com/simonpunk/susfs4ksu
-      rm -f common/android/abi_gki_protected_exports_*
-      rm -f msm-kernel/android/abi_gki_protected_exports_*
-    ''
-    + (lib.optionalString kernelSU.enable ''
-      # Force set KernelSU version
-      sed -i "/ version:/d" ${kernelSU.subdirectory}/kernel/Makefile
-      sed -i "/KSU_GIT_VERSION not defined/d" ${kernelSU.subdirectory}/kernel/Makefile
-      sed -i "s|ccflags-y += -DKSU_VERSION=|ccflags-y += -DKSU_VERSION=\"${kernelSU.revision}\"\n#|g" ${kernelSU.subdirectory}/kernel/Makefile
+    if [ -f security/Makefile ] && ! grep -q "baseband-guard" security/Makefile; then
+      echo "Adding BBG to security/Makefile"
+      echo "obj-\$(CONFIG_BBG) += baseband-guard/" >> security/Makefile
+    fi
 
-      bash ${kernelSU.subdirectory}/kernel/setup.sh
-    '')
-    + ''
-      sed -i "s|/bin/||g" Makefile
-    ''
-    + postPatch;
+    if [ -f security/Kconfig ] && ! grep -q "security/baseband-guard/Kconfig" security/Kconfig; then
+      echo "Adding BBG to security/Kconfig"
+      awk '
+        { a[NR]=$0 } END{
+          last=0; for(i=1;i<=NR;i++) if(a[i] ~ /^endmenu[[:space:]]*$/) last=i;
+          for(i=1;i<=NR;i++){
+            if(i==last) print "source \"security/baseband-guard/Kconfig\"";
+            print a[i];
+          }
+        }' security/Kconfig > security/Kconfig.tmp && mv security/Kconfig.tmp security/Kconfig
+    fi
+  '')
+  + ''
+    patchShebangs .
+
+    # These files may break Wi-Fi
+    # https://gitlab.com/simonpunk/susfs4ksu
+    rm -f common/android/abi_gki_protected_exports_*
+    rm -f msm-kernel/android/abi_gki_protected_exports_*
+  ''
+  + (lib.optionalString kernelSU.enable ''
+    # Force set KernelSU version
+    sed -i "/ version:/d" ${kernelSU.subdirectory}/kernel/Makefile
+    sed -i "/KSU_GIT_VERSION not defined/d" ${kernelSU.subdirectory}/kernel/Makefile
+    sed -i "s|ccflags-y += -DKSU_VERSION=|ccflags-y += -DKSU_VERSION=\"${kernelSU.revision}\"\n#|g" ${kernelSU.subdirectory}/kernel/Makefile
+
+    bash ${kernelSU.subdirectory}/kernel/setup.sh
+  '')
+  + ''
+    sed -i "s|/bin/||g" Makefile
+  ''
+  + postPatch;
 
   dontBuild = true;
 


### PR DESCRIPTION
Add support for [baseband-guard](https://github.com/vc-teahouse/Baseband-guard), a lightweight LSM (Linux Security Module) for the Android kernel, designed to block unauthorized writes to critical partitions/device nodes at the system level.